### PR TITLE
Release/0.0.7

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,32 @@
+---
+name: Checkov
+on:
+  push:
+    branches: [ "main", "master" ]
+  pull_request:
+    branches: [ "main", "master" ]
+
+jobs:
+  scan:
+    permissions:
+      contents: read
+      security-events: write   
+      actions: read           
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run Checkov (Terraform only)
+        uses: bridgecrewio/checkov-action@v12
+        with:
+          directory: .                 
+          framework: terraform        
+          output_format: cli,sarif     
+          output_file_path: console,results.sarif
+          # soft_fail: true            
+
+      - name: Upload SARIF to GitHub Security
+        uses: github/codeql-action/upload-sarif@v3
+        if: success() || failure()     
+        with:
+          sarif_file: results.sarif

--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ module "eventhub" {
   resource_group_name  = "my-rg"
   location             = "eastus"
   network_mode         = "private"
+  sku                = "Premium" 
+
   subnet_ids = [
     "/subscriptions/xxx/resourcegroups/my-rg/providers/microsoft.network/virtualnetworks/my-vnet/subnets/subnet1"
   ]
@@ -98,7 +100,8 @@ module "eventhub" {
   resource_group_name  = "my-rg"
   location             = "eastus"
   network_mode         = "service"
-  sku                  = "Premium"
+  # Standard or Premium are supported for service mode
+  sku                  = "Standard"
   subnet_ids = [
     "/subscriptions/xxx/resourcegroups/my-rg/providers/microsoft.network/virtualnetworks/my-vnet/subnets/subnet1"
   ]
@@ -123,6 +126,7 @@ module "eventhub" {
   resource_group_name  = "my-rg"
   location             = "eastus"
   network_mode         = "public"
+  sku                  = "Standard"
   tags = {
     environment = "dev"
     project     = "eventhub-provisioning"

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ this terraform module provisions an **azure event hub** namespace and its associ
 ## 1. features
 - support for **private**, **service**, and **public** access modes.
 - automatic provisioning of **private dns zones** and **virtual network links** if not provided.
-- configurable **ip rules** and **vnet rules** for service endpoint mode.
+- configurable **vnet rules** for service endpoint mode (applies when `sku = "Premium"`).
 - supports tagging, resource grouping, and subnet customization.
 ## 2. module usage
 ### 2.1. prerequisites
@@ -26,27 +26,25 @@ specify how the event hub should be exposed:
  
 | name                   | type           | required | default                | description                                                                 |
 | ---------------------- | -------------- | -------- | ---------------------- | --------------------------------------------------------------------------- |
-| `namespace`            | `string`       | ✅        | —                      | the name of the event hub.                                                  |
-| `topics`               | `list(string)` | ❌        | `[]`                   | the list of topics in the event hub namespace.                              |
+| `namespace`            | `string`       | ✅        | —                      | the name of the event hub namespace.                                        |
+| `topics`               | `list(object({ name = string, partition_count = optional(number), message_retention = optional(number) }))` | ❌ | `[]` | event hubs to create. per-hub overrides (defaults: 2 partitions, 7 days). |
 | `capacity`             | `number`       | ❌        | `1`                    | number of pus for the event hub namespace.                                  |
-| `partition_count`      | `number`       | ❌        | `1`                    | the number of partitions for each event hub (topic).                        |
 | `network_mode`         | `string`       | ✅        | —                      | network mode for event hub: `private`, `service`, `public`.                 |
 | `private_dns_zone_ids` | `list(string)` | ❌        | `[]`                   | the resource id of the private dns zone for event hub.                      |
-| `subnet_ids`           | `list(string)` | ❌        | `[]`                   | the resource id of the subnet.                     |
-| `ip_rules`             | `list(string)` | ❌        | `[]`                   | cidr blocks to allow access (only for service endpoints).                   |
+| `subnet_ids`           | `list(string)` | ❌        | `[]`                   | the resource id of the subnet.                                             |
 | `vnet_ids`             | `list(string)` | ❌        | `[]`                   | vnet ids used for linking to private dns zone (only for private endpoints). |
 | `resource_group_name`  | `string`       | ❌        | `"terraform-eventhub"` | the name of the resource group where the resources will be created.         |
 | `location`             | `string`       | ✅        | —                      | the azure location where the resources will be created.                     |
 | `tags`                 | `map(string)`  | ❌        | `{}`                   | tags to assign to the resources.                                            |
-| `sku`                | `string`       | ❌        | `"Premium"`           | the sku of the event hub namespace.                                         |
+| `sku`                  | `string`       | ❌        | `"Premium"`           | the sku of the event hub namespace.                                         |
  
 ### 2.4 example
 ### variable require by `network mode`
-| `network_mode`       | `private_dns_zone_ids` | `subnet_ids` | `vnet_ids` | `ip_rules` |
-| -------------------- | ---------------------- | ------------ | ---------- | ---------- |
-| **private endpoint** | 🟦                     | ✅ (at least 1)          | ✅         | ❌         |
-| **service endpoint** | ❌                     | ✅           | ❌         | 🟦         |
-| **public endpoint**  | ❌                     | ❌           | ❌         | ❌         |
+| `network_mode`       | `private_dns_zone_ids` | `subnet_ids` | `vnet_ids` |
+| -------------------- | ---------------------- | ------------ | ---------- |
+| **private endpoint** | 🟦                     | ✅ (at least 1) | ✅         |
+| **service endpoint** | ❌                     | ✅           | ❌         |
+| **public endpoint**  | ❌                     | ❌           | ❌         |
  
 ##### notes:
 - ✅ = **required** 
@@ -55,19 +53,19 @@ specify how the event hub should be exposed:
  
 #### main.tf 
 network mode - private
-- when use private mode, variable `subnet_ids` is where the ip of private endpoint will be created. so you just need at least one subnet id, all the subnets in the vnet will be conect to event hub.
+- when using private mode, `subnet_ids` is where the private endpoint ip will be created. you need at least one subnet id. if `private_dns_zone_ids` are not provided, a private dns zone and vnet links will be created and associated.
 ```hcl
 module "eventhub" {
   source  = "azure-terraform-module/event-hubs-kafka/azure"
   version = "0.0.3"
  
   # required variables
-  namespace         = "my-eventhub-private-mode" # must be unique name
-  resource_group_name   = "my-rg"
-  location              = "eastus"
-  network_mode = "private"
+  namespace            = "my-eventhub-private-mode" # must be unique name
+  resource_group_name  = "my-rg"
+  location             = "eastus"
+  network_mode         = "private"
   subnet_ids = [
-	"/subscriptions/xxx/resourcegroups/my-rg/providers/microsoft.network/virtualnetworks/my-vnet/subnets/subnet1"
+    "/subscriptions/xxx/resourcegroups/my-rg/providers/microsoft.network/virtualnetworks/my-vnet/subnets/subnet1"
   ]
   vnet_ids = [
 	"/subscriptions/xxx/resourcegroups/my rg/providers/microsoft.network/virtualnetworks/my-vnet"
@@ -82,38 +80,35 @@ module "eventhub" {
     project     = "eventhub-provisioning"
   }
   topics = [
-    "topic1",
-    "topic2"
+    { name = "topic1", partition_count = 4, message_retention = 7 },
+    { name = "topic2" } # defaults: 2 partitions, 7 days
   ]
 }
 ```
  
 network mode - service
-- when use service mode, subnet_ids is what subnet can access the event hub. so you need to add the subnet id that you want to access the event hub.
+- when using service mode, `subnet_ids` define which subnets can access the namespace via service endpoints. network rules are applied when `sku = "Premium"`.
 ```hcl
 module "eventhub" {
   source  = "azure-terraform-module/event-hubs-kafka/azure"
   version = "0.0.3"
  
   # required variables
-  namespace         = "my-eventhub-service-mode" 
-  resource_group_name   = "my-rg"
-  location              = "eastus"
-  network_mode = "service"
+  namespace            = "my-eventhub-service-mode" 
+  resource_group_name  = "my-rg"
+  location             = "eastus"
+  network_mode         = "service"
+  sku                  = "Premium"
   subnet_ids = [
     "/subscriptions/xxx/resourcegroups/my-rg/providers/microsoft.network/virtualnetworks/my-vnet/subnets/subnet1"
-  ]
-  # optional variables
-  ip_rules = [
-    "203.0.113.10"
   ]
   tags = {
     environment = "dev"
     project     = "eventhub-provisioning"
   }
   topics = [
-    "topic1",
-    "topic2"
+    { name = "topic1" },
+    { name = "topic2", partition_count = 8 }
   ]
 }
 ```
@@ -124,17 +119,17 @@ module "eventhub" {
   source  = "azure-terraform-module/event-hubs-kafka/azure"
   version = "0.0.3"
  
-  namespace         = "my-eventhub-public-mode"
-  resource_group_name   = "my-rg"
-  location              = "eastus"
-  network_mode = "public"
+  namespace            = "my-eventhub-public-mode"
+  resource_group_name  = "my-rg"
+  location             = "eastus"
+  network_mode         = "public"
   tags = {
     environment = "dev"
     project     = "eventhub-provisioning"
   }
   topics = [
-    "topic1",
-    "topic2"
+    { name = "topic1" },
+    { name = "topic2" }
   ]
 }
 ```
@@ -165,25 +160,45 @@ provider "azurerm" {
 }
 ```
  
-#### outputs.tf
+#### outputs.tf 
 ```hcl
 output "namespace" {
   description = "the name of the event hub namespace"
   value       = module.eventhub.namespace
 }
- 
+
 output "namespace_id" {
   description = "the id of the event hub namespace"
   value       = module.eventhub.namespace_id
-}  
- 
-output "topics" {
-  description = "list of event hub topics from the module"
-  value       = module.eventhub.topics
 }
- 
+
 output "hostname" {
   description = "the hostname of the event hub namespace"
   value       = module.eventhub.hostname
 }
-`
+
+output "eventhub_names" {
+  description = "names of event hubs (topics) created"
+  value       = module.eventhub.eventhub_names
+}
+
+output "eventhubs" {
+  description = "map of event hub name to event hub id"
+  value       = module.eventhub.eventhubs
+}
+
+output "private_endpoint_ids" {
+  description = "ids of private endpoints created (empty if not using private mode)"
+  value       = module.eventhub.private_endpoint_ids
+}
+
+output "private_dns_zone_ids" {
+  description = "private dns zone ids associated (created or provided)"
+  value       = module.eventhub.private_dns_zone_ids
+}
+
+output "vnet_link_ids" {
+  description = "ids of vnet links to the private dns zone (empty if not using private mode)"
+  value       = module.eventhub.vnet_link_ids
+}
+```

--- a/c3-locals.tf
+++ b/c3-locals.tf
@@ -37,13 +37,6 @@ locals {
         }
       ] : []
  
-      # IP rules - Service endpoints
-      ip_rule = local.is_service ? [
-        for ip in var.ip_rules : {
-          ip_mask = ip
-          action  = "Allow"
-      }] : []
     }
   ]
- 
 }

--- a/c4-eventhub-variables.tf
+++ b/c4-eventhub-variables.tf
@@ -8,7 +8,11 @@ variable "namespace" {
  
 variable "topics" {
   description = "The list of topics in the Event Hub Namespace."
-  type        = list(string)
+  type        = list(object({
+    name = string
+    partition_count = number
+    message_retention = number
+  }))
   default     = []
 }
  
@@ -17,18 +21,18 @@ variable "capacity" {
   type        = number
   default     = 1
 }
- 
-variable "partition_count" {
-  description = "The number of partitions for the Event Hub (topics)."
-  type        = number
-  default     = 1
-}
- 
+
 variable "network_mode" {
-  type = string
+  description = "Network mode for Service bus private, service, public."
+  type        = string
+  default     = "public"
   validation {
-    condition     = contains(["private", "service", "public"], var.network_mode)
-    error_message = "network_mode must be one of private, service, or public"
+    condition = var.sku != "Premium" && contains(["private", "service"], var.network_mode) ? false : true
+    error_message = "Network mode private and service are only supported for Premium SKU."
+  }
+  validation {
+    condition     = contains(["public", "private", "service"], var.network_mode)
+    error_message = "network_mode must be one of: public, private, service."
   }
 }
  
@@ -49,12 +53,6 @@ variable "private_dns_zone_ids" {
  
 variable "subnet_ids" {
   description = "The resource ID of the subnet for the private endpoint."
-  type        = list(string)
-  default     = []
-}
- 
-variable "ip_rules" {
-  description = "CIDR blocks to allow access to the Event Hub - Only for service endpoints."
   type        = list(string)
   default     = []
 }

--- a/c4-eventhub-variables.tf
+++ b/c4-eventhub-variables.tf
@@ -10,8 +10,8 @@ variable "topics" {
   description = "The list of topics in the Event Hub Namespace."
   type        = list(object({
     name = string
-    partition_count = number
-    message_retention = number
+    partition_count = optional(number)
+    message_retention = optional(number) 
   }))
   default     = []
 }
@@ -23,12 +23,12 @@ variable "capacity" {
 }
 
 variable "network_mode" {
-  description = "Network mode for Service bus private, service, public."
+  description = "Network mode for Event Hubs: private, service, or public."
   type        = string
   default     = "public"
   validation {
-    condition = var.sku != "Premium" && contains(["private", "service"], var.network_mode) ? false : true
-    error_message = "Network mode private and service are only supported for Premium SKU."
+    condition     = !(var.sku == "Basic" && contains(["private", "service"], var.network_mode))
+    error_message = "Network modes 'private' and 'service' are not supported for Basic SKU. Use Standard or Premium."
   }
   validation {
     condition     = contains(["public", "private", "service"], var.network_mode)

--- a/c5-eventhub-module.tf
+++ b/c5-eventhub-module.tf
@@ -45,7 +45,7 @@ resource "azurerm_private_endpoint" "eventhub_private_endpoint" {
     for_each = length(local.private_dns_zone_ids) > 0 ? [1] : []
     content {
       name                 = "default"
-      private_dns_zone_ids = local.eventhub_private_dns_zone_ids
+      private_dns_zone_ids = local.private_dns_zone_ids
     }
   }
  

--- a/c5-eventhub-module.tf
+++ b/c5-eventhub-module.tf
@@ -72,6 +72,8 @@ resource "azurerm_eventhub_namespace" "eventhub_namespace" {
      content {
       default_action                 = network_rulesets.value.default_action
       public_network_access_enabled  = network_rulesets.value.public_network_access_enabled
+      virtual_network_rule = network_rulesets.value.virtual_network_rule
+      trusted_service_access_enabled = network_rulesets.value.trusted_service_access_enabled
     }
   }
  

--- a/c5-eventhub-module.tf
+++ b/c5-eventhub-module.tf
@@ -71,9 +71,7 @@ resource "azurerm_eventhub_namespace" "eventhub_namespace" {
     for_each = var.sku != "Basic" ? local.network_rulesets : []
      content {
       default_action                 = network_rulesets.value.default_action
-      trusted_service_access_enabled = network_rulesets.value.trusted_service_access_enabled
       public_network_access_enabled  = network_rulesets.value.public_network_access_enabled
-      virtual_network_rule           = network_rulesets.value.virtual_network_rule
     }
   }
  

--- a/c5-eventhub-module.tf
+++ b/c5-eventhub-module.tf
@@ -68,7 +68,7 @@ resource "azurerm_eventhub_namespace" "eventhub_namespace" {
   public_network_access_enabled = local.public_network_access
  
   dynamic "network_rulesets" {
-    for_each = var.sku == "Premium" ? local.network_rulesets : []
+    for_each = var.sku != "Basic" ? local.network_rulesets : []
      content {
       default_action                 = network_rulesets.value.default_action
       trusted_service_access_enabled = network_rulesets.value.trusted_service_access_enabled

--- a/c6-outputs.tf
+++ b/c6-outputs.tf
@@ -1,19 +1,39 @@
-output "namespace" {
-  description = "The name of the Event Hub Namespace"
-  value       = azurerm_eventhub_namespace.eventhub_namespace.name
-}
- 
 output "namespace_id" {
-  description = "The ID of the Event Hub Namespace"
+  description = "The ID of the Event Hubs namespace"
   value       = azurerm_eventhub_namespace.eventhub_namespace.id
 }
 
-output "topics" {
-  description = "The list of topics in the Event Hub Namespace"
-  value       = [for eh in azurerm_eventhub.eventhub : eh.name]
+output "namespace" {
+  description = "The name of the Event Hubs namespace"
+  value       = azurerm_eventhub_namespace.eventhub_namespace.name
 }
- 
+
 output "hostname" {
-  description = "The hostname of the Event Hub Namespace"
+  description = "The hostname of the Event Hubs namespace"
   value       = "${azurerm_eventhub_namespace.eventhub_namespace.name}.servicebus.windows.net"
+}
+
+output "eventhub_names" {
+  description = "Names of Event Hubs created in the namespace"
+  value       = keys(azurerm_eventhub.eventhub_topic)
+}
+
+output "eventhubs" {
+  description = "Map of Event Hub name to Event Hub ID"
+  value       = { for name, eh in azurerm_eventhub.eventhub_topic : name => eh.id }
+}
+
+output "private_endpoint_ids" {
+  description = "IDs of private endpoints created for the Event Hubs namespace (empty if not using private mode)"
+  value       = [for pe in azurerm_private_endpoint.eventhub_private_endpoint : pe.id]
+}
+
+output "private_dns_zone_ids" {
+  description = "Private DNS zone IDs associated with the namespace (created or provided)"
+  value       = local.private_dns_zone_ids
+}
+
+output "vnet_link_ids" {
+  description = "IDs of VNet links to the private DNS zone (empty if not using private mode)"
+  value       = [for l in azurerm_private_dns_zone_virtual_network_link.eventhub_private_dns_zone_link : l.id]
 }


### PR DESCRIPTION
This version enable to create event hub with standard/basic tier 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* New Features
  * Per-topic Event Hub settings (partition_count, message_retention) with defaults; new outputs exposing event hub names, map, private endpoint IDs, private DNS zone IDs, and VNet link IDs.
* Refactor
  * Per-topic resource mapping; network rules now applied only for non-Basic SKUs; removed per-IP service endpoint rules (subnet-only access).
  * Removed top-level partition_count and ip_rules inputs; added SKU and vnet linking support.
* Documentation
  * README updated for topics schema, network modes, examples, and outputs.
* Chores
  * Added automated Terraform security scan workflow with SARIF upload.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->